### PR TITLE
NPM meta data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
-  - "6"
+  - lts/argon
+  - lts/boron
 script:
-  - node test.js
+  - npm t

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Service Worker implementation of Cache Digests for HTTP/2 (draft 01) https://tools.ietf.org/html/draft-kazuho-h2-cache-digest-01",
   "main": "cache-digest.js",
+  "bin": "cli.js",
   "scripts": {
     "test": "node test.js"
   },

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "cache-digest",
+  "version": "1.0.0",
+  "description": "Service Worker implementation of Cache Digests for HTTP/2 (draft 01) https://tools.ietf.org/html/draft-kazuho-h2-cache-digest-01",
+  "main": "cache-digest.js",
+  "scripts": {
+    "test": "node test.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/h2o/cache-digest.js.git"
+  },
+  "keywords": [
+    "http2",
+    "cache digests",
+    "server push",
+    "bloom filter",
+    "golomb coding"
+  ],
+  "author": "Kazuho Oku <kazuhooku@gmail.com>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/h2o/cache-digest.js/issues"
+  },
+  "homepage": "https://github.com/h2o/cache-digest.js#readme"
+}


### PR DESCRIPTION
It would be great to publish this to the NPM registry. Even though nothing is exported, NPM makes it easier to bundle it with other apps.

Note: I set the name as `cache-digests` instead of `cache-digests.js`. It's conventional to omit the file extension in NPM.

PS: Also running the Travis CI tests on both LTS versions.