### PR TITLE
`cache-digest` CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,16 @@
-cache-digest.js
-======
+# cache-digest.js
 
 [![Build Status](https://travis-ci.org/h2o/cache-digest.js.svg?branch=master)](https://travis-ci.org/h2o/cache-digest.js)
 
 [Service Worker](https://developer.mozilla.org/docs/Web/API/Service_Worker_API) implementation of [Cache Digests for HTTP/2 (draft 01)](https://tools.ietf.org/html/draft-kazuho-h2-cache-digest-01)
 
-Warning
-------
+## Warning
+
 
 * WIP; the code is in early-beta stage
 * only supports sending of _fresh_ digests without etag
 
-How to Use
-------
+## How to Use
 
 1. install cache-digest.js into the root directory of the website
 2. add `<script src="/cache-digest.js"></script>` to your web pages
@@ -20,14 +18,40 @@ How to Use
  * `service-worker-allowed: /` response header
  * `link: <push-URL>; rel="preload"` response header (see [spec](https://w3c.github.io/preload/))
 
-Calculating Digests at Command Line
-------
+## Command Line Interface
 
-You can run cli.js to calculate cache digests manually.
-
-```
-% node cli.js -b https://example.com/style.css https://example.com/jquery.js https://example.com/shortcut.css
-EeUM-QA
+```bash
+Usage: cache-digest [-b] [-p=pbits] URL1 URL2...
 ```
 
-In the above example, `-b` option is used so that the digest would be encoded using [base64url](https://tools.ietf.org/html/rfc4648#section-5). Please refer to `-h` (help) option for more information.
+Install using NPM to provide a command line interface.
+
+```bash
+# locally for npm scripts
+npm install cache-digest-cli
+
+# or globally for system-wide use
+npm install --global cache-digest-cli
+```
+
+Example:
+```bash
+cache-digest -b https://example.com/style.css https://example.com/jquery.js https://example.com/shortcut.css
+# Output: EeUM-QA
+```
+
+### Options
+
+#### `-b`
+
+Encode the digest as per the [base64url](https://tools.ietf.org/html/rfc4648#section-5) specification.
+
+If this option is not specified the output is streamed as raw binary data to `STDOUT`.
+
+#### `-p=pbits`
+
+Where **pbits** is an integer representing the probability of collisions. Maximum 31 bits per hash.
+
+#### `-h` or `--help`
+
+Display help information.

--- a/cli.js
+++ b/cli.js
@@ -37,7 +37,7 @@ function main(argv) {
         if (opt == "-")
             break;
         if (opt == "-h" || opt == "--help") {
-            console.log("Usage: node cmd.js [-b] [-p=pbits] URL1 URL2...")
+            console.log("Usage: cache-digest [-b] [-p=pbits] URL1 URL2...")
             return 0;
         } else if (opt == "-b") {
             useBase64 = 1;

--- a/package.json
+++ b/package.json
@@ -1,9 +1,11 @@
 {
-  "name": "cache-digest",
+  "name": "cache-digest-cli",
   "version": "1.0.0",
   "description": "Service Worker implementation of Cache Digests for HTTP/2 (draft 01) https://tools.ietf.org/html/draft-kazuho-h2-cache-digest-01",
   "main": "cache-digest.js",
-  "bin": "cli.js",
+  "bin": {
+    "cache-digest": "cli.js"
+  },
   "scripts": {
     "test": "node test.js"
   },


### PR DESCRIPTION
- NPM package name changed to `cache-digest-cli`
- NPM installation of the `cache-digest` "binary"
- Documentation of CLI usage

As proposed here https://github.com/h2o/cache-digest.js/pull/3#issuecomment-264387251
/cc @kazuho 